### PR TITLE
Add interactive backend roadmap

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>バックエンド学習ロードマップ</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <main class="container">
+    <header>
+      <h1>バックエンド学習ロードマップ</h1>
+      <p>各項目をクリックして状態（習得済み / 未習得 / チャレンジ中）とメモを管理しましょう。</p>
+    </header>
+    <div id="roadmap" class="roadmap"></div>
+  </main>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,233 @@
+const ROADMAP_STORAGE_PREFIX = "roadmap_item_";
+const STATUS_OPTIONS = ["未習得", "チャレンジ中", "習得済み"];
+
+const roadmapData = [
+  {
+    id: "foundations",
+    name: "バックエンドの基礎",
+    description: "HTTPやAPIの基本概念、リクエストとレスポンスの流れを理解する。",
+    children: [
+      {
+        id: "http",
+        name: "HTTPプロトコル",
+        description: "メソッド、ステータスコード、ヘッダーなどの仕様を理解する。"
+      },
+      {
+        id: "rest",
+        name: "REST / API デザイン",
+        description: "リソース設計、エンドポイント設計、認証・認可の基本を学ぶ。"
+      },
+      {
+        id: "architecture",
+        name: "サーバーサイドアーキテクチャ",
+        description: "MVCやClean Architectureなどのレイヤー構造を理解する。"
+      }
+    ]
+  },
+  {
+    id: "application-layer",
+    name: "アプリケーション層",
+    description: "ビジネスロジックやサービス層の設計パターンを学ぶ。",
+    children: [
+      {
+        id: "framework",
+        name: "Webフレームワーク",
+        description: "Express, Spring, Rails などのフレームワークでのルーティング・ミドルウェアの扱い。"
+      },
+      {
+        id: "validation",
+        name: "入力バリデーション",
+        description: "リクエストデータの検証、エラーハンドリング、レスポンス設計。"
+      },
+      {
+        id: "testing",
+        name: "テスト戦略",
+        description: "ユニットテスト・統合テスト・エンドツーエンドテストの役割を把握する。"
+      }
+    ]
+  },
+  {
+    id: "data-layer",
+    name: "データ層",
+    description: "永続化の責務、データモデルとアクセス方法を理解する。",
+    children: [
+      {
+        id: "database",
+        name: "データベース設計",
+        description: "リレーショナル/NoSQLの選定、スキーマ設計、正規化と非正規化。"
+      },
+      {
+        id: "orm",
+        name: "ORM / クエリビルダー",
+        description: "ORMの利用パターン、トランザクション、マイグレーション管理。"
+      },
+      {
+        id: "caching",
+        name: "キャッシュ戦略",
+        description: "Redisなどを用いたキャッシュ、キャッシュ失効の設計。"
+      }
+    ]
+  },
+  {
+    id: "infrastructure",
+    name: "インフラ・運用",
+    description: "アプリケーションを支えるインフラや運用のポイントを押さえる。",
+    children: [
+      {
+        id: "deployment",
+        name: "デプロイメント",
+        description: "CI/CD、コンテナ、クラウドサービスへのデプロイ方法。"
+      },
+      {
+        id: "observability",
+        name: "モニタリングとロギング",
+        description: "ログ収集、メトリクス、トレーシングによる可観測性の確保。"
+      },
+      {
+        id: "security",
+        name: "セキュリティ",
+        description: "脆弱性対策、アクセス制御、秘密情報管理。"
+      }
+    ]
+  }
+];
+
+document.addEventListener("DOMContentLoaded", () => {
+  const container = document.getElementById("roadmap");
+  container.appendChild(createList(roadmapData));
+});
+
+function createList(items) {
+  const list = document.createElement("ul");
+
+  items.forEach((item) => {
+    const listItem = createRoadmapItem(item);
+    list.appendChild(listItem);
+  });
+
+  return list;
+}
+
+function createRoadmapItem(item) {
+  const listItem = document.createElement("li");
+  listItem.className = "roadmap-item";
+
+  const storedState = loadItemState(item.id);
+  const currentStatus = storedState.status || STATUS_OPTIONS[0];
+  listItem.dataset.status = currentStatus;
+
+  const headerButton = document.createElement("button");
+  headerButton.type = "button";
+  headerButton.className = "item-header";
+
+  const titleWrapper = document.createElement("div");
+  const title = document.createElement("div");
+  title.textContent = item.name;
+  const description = document.createElement("div");
+  description.textContent = item.description;
+  description.className = "item-description";
+  titleWrapper.appendChild(title);
+  titleWrapper.appendChild(description);
+
+  const statusPill = document.createElement("span");
+  statusPill.className = "status-pill";
+  statusPill.dataset.status = currentStatus;
+  statusPill.textContent = currentStatus;
+
+  headerButton.appendChild(titleWrapper);
+  headerButton.appendChild(statusPill);
+
+  headerButton.addEventListener("click", () => {
+    const isActive = body.classList.toggle("active");
+    saveItemState(item.id, {
+      ...loadItemState(item.id),
+      expanded: isActive
+    });
+  });
+
+  const body = document.createElement("div");
+  body.className = "item-body";
+  if (storedState.expanded) {
+    body.classList.add("active");
+  }
+
+  const controls = document.createElement("div");
+  controls.className = "controls";
+
+  const statusLabel = document.createElement("label");
+  statusLabel.textContent = "状態";
+  const statusSelect = document.createElement("select");
+  STATUS_OPTIONS.forEach((status) => {
+    const option = document.createElement("option");
+    option.value = status;
+    option.textContent = status;
+    if (status === currentStatus) {
+      option.selected = true;
+    }
+    statusSelect.appendChild(option);
+  });
+
+  statusSelect.addEventListener("change", (event) => {
+    const newStatus = event.target.value;
+    statusPill.textContent = newStatus;
+    statusPill.dataset.status = newStatus;
+    listItem.dataset.status = newStatus;
+    saveItemState(item.id, {
+      ...loadItemState(item.id),
+      status: newStatus
+    });
+  });
+
+  statusLabel.appendChild(statusSelect);
+
+  const memoLabel = document.createElement("label");
+  memoLabel.textContent = "メモ";
+  const memoTextarea = document.createElement("textarea");
+  memoTextarea.placeholder = "学んだことや疑問点をメモしましょう";
+  memoTextarea.value = storedState.memo || "";
+  memoTextarea.addEventListener("input", (event) => {
+    saveItemState(item.id, {
+      ...loadItemState(item.id),
+      memo: event.target.value
+    });
+  });
+  memoLabel.appendChild(memoTextarea);
+
+  controls.appendChild(statusLabel);
+  controls.appendChild(memoLabel);
+
+  body.appendChild(controls);
+
+  if (item.children && item.children.length > 0) {
+    const childrenWrapper = document.createElement("div");
+    childrenWrapper.className = "children";
+    childrenWrapper.appendChild(createList(item.children));
+    body.appendChild(childrenWrapper);
+  }
+
+  listItem.appendChild(headerButton);
+  listItem.appendChild(body);
+
+  return listItem;
+}
+
+function loadItemState(id) {
+  try {
+    const raw = sessionStorage.getItem(ROADMAP_STORAGE_PREFIX + id);
+    return raw ? JSON.parse(raw) : {};
+  } catch (error) {
+    console.error("Failed to load state", error);
+    return {};
+  }
+}
+
+function saveItemState(id, state) {
+  try {
+    sessionStorage.setItem(
+      ROADMAP_STORAGE_PREFIX + id,
+      JSON.stringify({ ...state })
+    );
+  } catch (error) {
+    console.error("Failed to save state", error);
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,172 @@
+:root {
+  --bg: #f5f5f7;
+  --card-bg: #ffffff;
+  --border: #d0d7de;
+  --text: #202124;
+  --accent: #2563eb;
+  --completed: #16a34a;
+  --in-progress: #d97706;
+  --not-started: #6b7280;
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Segoe UI", "Hiragino Sans", "BIZ UDPGothic", sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 3rem;
+}
+
+header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+header h1 {
+  margin-bottom: 0.5rem;
+  font-size: 2rem;
+}
+
+.roadmap ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.roadmap-item {
+  margin: 0.5rem 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--card-bg);
+  overflow: hidden;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.roadmap-item[data-status="習得済み"] {
+  border-color: var(--completed);
+}
+
+.roadmap-item[data-status="チャレンジ中"] {
+  border-color: var(--in-progress);
+}
+
+.roadmap-item[data-status="未習得"] {
+  border-color: var(--not-started);
+}
+
+.item-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 0.85rem 1rem;
+  background: transparent;
+  border: none;
+  text-align: left;
+  font-size: 1rem;
+  font-weight: 600;
+  color: inherit;
+  cursor: pointer;
+}
+
+.item-header:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.item-description {
+  font-size: 0.9rem;
+  color: #4b5563;
+}
+
+.status-pill {
+  padding: 0.2rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #fff;
+}
+
+.status-pill[data-status="習得済み"] {
+  background: var(--completed);
+}
+
+.status-pill[data-status="チャレンジ中"] {
+  background: var(--in-progress);
+}
+
+.status-pill[data-status="未習得"] {
+  background: var(--not-started);
+}
+
+.item-body {
+  display: none;
+  padding: 0 1rem 1rem;
+  border-top: 1px solid var(--border);
+  background: #fafafa;
+}
+
+.item-body.active {
+  display: block;
+}
+
+.controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+.controls label {
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.controls select,
+.controls textarea {
+  width: 100%;
+  padding: 0.6rem;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  font-size: 0.9rem;
+  font-family: inherit;
+  resize: vertical;
+}
+
+.controls textarea {
+  min-height: 90px;
+}
+
+.children {
+  margin-left: 1.5rem;
+  border-left: 2px dashed #d1d5db;
+  padding-left: 1rem;
+}
+
+@media (max-width: 600px) {
+  .container {
+    padding: 1.5rem 1rem 2.5rem;
+  }
+
+  header h1 {
+    font-size: 1.6rem;
+  }
+
+  .item-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add static HTML scaffold for the backend learning roadmap
- implement dynamic roadmap generation with sessionStorage persistence
- style roadmap with responsive layout and status-based accents

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cd29efd1e88325a549fd2ac8c7fc35