### PR TITLE
Add GitHub Actions mock site URL to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # roadmap_mock
+
+GitHub Actionsで自動公開されるモックサイトはこちらから確認できます。
+
+https://<GitHubユーザー名>.github.io/roadmap_mock/


### PR DESCRIPTION
## Summary
- document the GitHub Actions mock site URL in the README for easy access

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6906f0b98b7c8325a9a85aa16e503223