### PR TITLE
Add evaluation selectors for skill items

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -129,9 +129,23 @@ header h1 {
   margin-top: 0.75rem;
 }
 
-.controls label {
-  font-weight: 600;
+.evaluation-group {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem;
+}
+
+.evaluation-field,
+.memo-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
   font-size: 0.85rem;
+}
+
+.evaluation-field span,
+.memo-field span {
+  font-weight: 600;
 }
 
 .controls select,


### PR DESCRIPTION
## Summary
- add selectors for status, self evaluation, and other evaluation to each roadmap item
- persist the new evaluation values alongside existing memo data in session storage
- style the evaluation controls so the three selectors appear horizontally

## Testing
- Manual UI verification

------
https://chatgpt.com/codex/tasks/task_e_6906f3a21a6883259c7097bf06cd656a