### PR TITLE
Remove skill subcategory display from roadmap items

### DIFF
--- a/script.js
+++ b/script.js
@@ -391,7 +391,6 @@ function createRoadmapItem(item) {
   const meta = document.createElement("dl");
   meta.className = "item-meta";
   appendMeta(meta, "成果物・作業メニュー", item.deliverable);
-  appendMeta(meta, "スキル小分類", item.skillSubcategory);
   appendMeta(meta, "必要スキル", item.requiredSkill);
   if (meta.childElementCount > 0) {
     body.appendChild(meta);


### PR DESCRIPTION
## Summary
- remove the skill subcategory entry from the roadmap item metadata to avoid duplicate labeling

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_6906ff072cf08325bc94a0f29ccb6272