### PR TITLE
Add category completion summary panel

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -37,6 +37,80 @@ header h1 {
   font-size: 2rem;
 }
 
+.category-summary {
+  margin-bottom: 2rem;
+  padding: 1.5rem 1.75rem;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--card-bg);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.05);
+}
+
+.category-summary h2 {
+  margin: 0 0 1rem;
+  font-size: 1.25rem;
+}
+
+.category-summary-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.category-summary-item {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem 1.25rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.category-summary-code {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  background: var(--accent);
+  color: #fff;
+  font-weight: 700;
+}
+
+.category-summary-label {
+  flex: 1 1 auto;
+  min-width: 160px;
+}
+
+.category-summary-progress {
+  color: #4b5563;
+  font-variant-numeric: tabular-nums;
+}
+
+.category-summary-status {
+  font-weight: 700;
+}
+
+.category-summary-status[data-status="習得済み"] {
+  color: var(--completed);
+}
+
+.category-summary-status[data-status="チャレンジ中"] {
+  color: var(--in-progress);
+}
+
+.category-summary-status[data-status="未修得"] {
+  color: var(--not-started);
+}
+
+.category-summary-status[data-status="対象なし"] {
+  color: #6b7280;
+}
+
 .roadmap ul {
   list-style: none;
   margin: 0;
@@ -254,6 +328,21 @@ header h1 {
 
   header h1 {
     font-size: 1.6rem;
+  }
+
+  .category-summary {
+    padding: 1.25rem 1.5rem;
+  }
+
+  .category-summary-item {
+    gap: 0.5rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .category-summary-code {
+    width: 1.75rem;
+    height: 1.75rem;
+    font-size: 0.9rem;
   }
 
   .item-header {


### PR DESCRIPTION
## Summary
- add a skill category completion summary above the main roadmap list
- track category totals and completion counts as item statuses change
- style the summary panel for desktop and mobile layouts

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6907011db0088325b7790b9b5f406396