### PR TITLE
Use radar charts for skill status overview

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
     </header>
     <div id="roadmap" class="roadmap"></div>
   </main>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="script.js"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -51,64 +51,30 @@ header h1 {
   font-size: 1.25rem;
 }
 
-.category-summary-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+.summary-charts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+}
+
+.summary-chart-block {
+  flex: 1 1 280px;
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
 }
 
-.category-summary-item {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.75rem 1.25rem;
-  font-size: 0.95rem;
-  font-weight: 600;
+.summary-chart-block h3 {
+  margin: 0;
+  font-size: 1rem;
+  color: #1f2937;
 }
 
-.category-summary-code {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2rem;
-  height: 2rem;
-  border-radius: 50%;
-  background: var(--accent);
-  color: #fff;
-  font-weight: 700;
-}
-
-.category-summary-label {
-  flex: 1 1 auto;
-  min-width: 160px;
-}
-
-.category-summary-progress {
-  color: #4b5563;
-  font-variant-numeric: tabular-nums;
-}
-
-.category-summary-status {
-  font-weight: 700;
-}
-
-.category-summary-status[data-status="習得済み"] {
-  color: var(--completed);
-}
-
-.category-summary-status[data-status="チャレンジ中"] {
-  color: var(--in-progress);
-}
-
-.category-summary-status[data-status="未修得"] {
-  color: var(--not-started);
-}
-
-.category-summary-status[data-status="対象なし"] {
-  color: #6b7280;
+.summary-chart-canvas {
+  width: 100%;
+  max-width: 100%;
+  aspect-ratio: 1;
+  min-height: 260px;
 }
 
 .roadmap ul {


### PR DESCRIPTION
## Summary
- replace the classification summary list with a dual radar chart section headed "習得状況"
- add Chart.js-based radar visualizations for skill categories and top-level items with dynamic updates
- style the new summary block so the two radar charts sit side-by-side and remain responsive

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6907036fe1508325ad59a982623e546d